### PR TITLE
Add option to save and restore a checkpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+/test

--- a/optimizer/mopso.py
+++ b/optimizer/mopso.py
@@ -18,6 +18,7 @@ Both classes are designed to be used in conjunction to perform the MOPSO optimiz
 find the Pareto front of non-dominated solutions.
 """
 import numpy as np
+import os
 import copy
 
 class Particle:
@@ -210,7 +211,7 @@ class MOPSO:
         self.pareto_front = []
         self.history = []
 
-    def optimize(self):
+    def optimize(self, history_dir=None):
         """
         Perform the MOPSO optimization process and return the Pareto front of non-dominated
         solutions.
@@ -218,7 +219,7 @@ class MOPSO:
         Returns:
             list: List of Particle objects representing the Pareto front of non-dominated solutions.
         """
-        for _ in range(self.num_iterations):
+        for i in range(self.num_iterations):
             if self.optimization_mode == 'global':
                 optimization_output = [objective_function([particle.position for
                                                            particle in self.particles])
@@ -240,6 +241,14 @@ class MOPSO:
                                          self.inertia_weight,
                                          self.cognitive_coefficient,
                                          self.social_coefficient)
+            
+            if history_dir:
+                if not os.path.exists(history_dir):
+                    os.mkdir(history_dir)
+                np.savetxt(history_dir + '/iteration' + str(i) + '.csv', 
+                           [np.concatenate([particle.position, np.ravel(particle.fitness)]) for particle in self.particles],
+                           fmt='%.18f',
+                           delimiter=',')
                 
             self.update_pareto_front()
                 

--- a/optimizer/mopso.py
+++ b/optimizer/mopso.py
@@ -121,7 +121,7 @@ class Particle:
             others (list): List of other particles.
 
         Returns:
-            list: List of Particle objects representing the Pareto front.
+            bool: True if the particle is dominated, False otherwise
         """
         for particle in others:
             if np.all(self.fitness >= particle.fitness) and \
@@ -169,6 +169,7 @@ class MOPSO:
         particles (list): List of Particle objects representing the swarm.
         global_best_position (numpy.ndarray): Global best position in the swarm.
         global_best_fitness (list): Global best fitness values achieved in the swarm.
+        pareto_front (list): List of Particle objects representing the Pareto front of non-dominated solutions across all iterations.
         history (list): List to store the global best fitness values at each iteration.
 
     Methods:
@@ -214,7 +215,11 @@ class MOPSO:
     def optimize(self, history_dir=None):
         """
         Perform the MOPSO optimization process and return the Pareto front of non-dominated
-        solutions.
+        solutions. If `history_dir` is specified, the position and fitness of all particles 
+        are saved every iteration.
+        
+        Parameters:
+            history_dir (str): path to the folder where history is saved.
 
         Returns:
             list: List of Particle objects representing the Pareto front of non-dominated solutions.


### PR DESCRIPTION
This PR added the option to save a checkpoint, which can be restored later to continue the optimization. This is useful when you want to test out different PSO parameters, as you will be able to run a few iterations, inspect the result, and continue the run if the result is good. 

Dependent on #2.