### PR TITLE
Make particles move toward points on the pareto front instead of a single global best

### DIFF
--- a/optimizer/mopso.py
+++ b/optimizer/mopso.py
@@ -19,6 +19,8 @@ find the Pareto front of non-dominated solutions.
 """
 import numpy as np
 import copy
+import json
+import random
 
 class Particle:
     """
@@ -61,13 +63,13 @@ class Particle:
             social_coefficient (float): Social coefficient controlling the impact of global best
                                         (default is 1).
         """
-        nearest_leader = self.nearest_neighbor(pareto_front)
+        leader = random.choice(pareto_front)
         cognitive_random = np.random.uniform(0, 1)
         social_random = np.random.uniform(0, 1)
         cognitive = cognitive_coefficient * cognitive_random * \
             (self.best_position - self.position)
         social = social_coefficient * social_random * \
-            (nearest_leader.position - self.position)
+            (leader.position - self.position)
         self.velocity = inertia_weight * self.velocity + cognitive + social
 
     def update_position(self, lower_bound, upper_bound):
@@ -112,19 +114,6 @@ class Particle:
         if np.all(self.fitness < self.best_fitness):
             self.best_fitness = self.fitness
             self.best_position = self.position
-            
-    def nearest_neighbor(self, others):
-        min_dist = np.inf
-        nearest = None
-        for other in others:
-            dist = self.distance(other)
-            if dist < min_dist:
-                min_dist = dist
-                nearest = other
-        return nearest
-    
-    def distance(self, other):
-        return np.linalg.norm(other.position - self.position)
             
     def is_dominated(self, others):
         """


### PR DESCRIPTION
Right now, a particle's velocity is updated based on the global best. However, since we have multiple equally good solutions, the global best is just the first one that appears, which is a bit arbitrary. This can cause particles to cluster in a particular region. 

I'd suggest that we choose multiple particles on the pareto front as "swarm leaders" instead of a single one. In this PR, I just pick a random point on pareto front for each particle to follow, but there can be heuristic approaches to choose swarm leaders, which we can explore later. 

For comparison, here are the results from running pixel track optimization:

- With a single global best:
![metrics](https://github.com/cms-patatrack/The-Optimizer/assets/72154050/38cb07b3-262c-4fa1-96b2-e00c23b38b1d)
![pareto_front](https://github.com/cms-patatrack/The-Optimizer/assets/72154050/7732f512-0fef-49d7-a485-e43812da1260)

- With multiple swarm leaders:
![metrics](https://github.com/cms-patatrack/The-Optimizer/assets/72154050/9a69c968-b7e2-4c2b-9ec3-2af1d351790d)
![pf](https://github.com/cms-patatrack/The-Optimizer/assets/72154050/47d3bee4-972d-475a-ad14-2357e46607fe)


With multiple swarm leaders, the particles converge more nicely to a curve, and particles are more evenly distributed on the pareto front.

This PR is dependent on #3.
