### PR TITLE
Adding Iterations to Objective

### DIFF
--- a/optimizer/objective.py
+++ b/optimizer/objective.py
@@ -9,8 +9,8 @@ class Objective():
             self.num_objectives = num_objectives
         pass
     
-    def evaluate(self, items):
-        return np.array([objective_function([item for item in items]) for objective_function in self.objective_functions])
+    def evaluate(self, items, iter):
+        return np.array([objective_function([item for item in items], iter = iter) for objective_function in self.objective_functions])
     
     def type(self):
         return self.__class__.__name__


### PR DESCRIPTION
Nothing special, just adding the number of the iteration on which we are to the objective function. A bit of context: when building https://github.com/cms-pixel-autotuning/CA-parameter-tuning/pull/4 I noticed that having the number of the iteration we are running on in the objective function could be useful from time to time. 

In that specific case, since the outputs are redirect to logs it's useful to keep track of each log per iteration.

```python

def reco_and_validate(params,config,iter,**kwargs):

     workdir = os.getcwd() 
     num_particles = len(params)

     # setting up temp folder
     if not os.path.exists('temp'):
         os.mkdir('temp')

     # writing current input parameters from mopso
     write_csv('temp/parameters.csv', params)
     validation_result = 'temp/simple_validation.root'


     # redirecting outputs to logs
     logfiles = tuple('%s/logs/%s_%d' % (workdir, name,iter) for name in ['process_last_out', 'process_last_err'])
     stdout = open(logfiles[0], 'w')
     stderr = open(logfiles[1], 'w')

     command = ['cmsRun',config,'parametersFile=temp/parameters.csv', 'outputFile=' + validation_result]    
     subprocess.run(command,stdout = stdout, stderr = stderr)

     with uproot.open(validation_result) as uproot_file:
         population_fitness = [get_metrics(uproot_file, i) for i in range(num_particles)]

     return population_fitness
     
   ```

In general, for a generic `objective` function, once could use `**kwargs` after the mandatory `params` input for anything extra. This is basically the only modification I did to the optimizer itself for the automatic optimization. I would have tested it with one of the examples but apparently, at the moment, they are not runnable.