### PR TITLE
fix `get_dominated` function

### DIFF
--- a/optimizer/mopso/mopso.py
+++ b/optimizer/mopso/mopso.py
@@ -367,7 +367,8 @@ def get_dominated(particles, pareto_lenght):
     dominated_particles = np.zeros(len(particles))
     for i in range(len(particles)):
         dominated = False
-        for j in range(pareto_lenght, len(particles)):
+        for j in range(len(particles)):
+            if i < pareto_lenght and j < pareto_lenght: continue
             if np.any(particles[i] > particles[j]) and \
                     np.all(particles[i] >= particles[j]):
                 dominated = True


### PR DESCRIPTION
I added to `get_dominated` function another check on the i index. The previous code checks only if a new particle is dominated by another one already in the pareto, discarding the opposite check i.e. if a pareto one is dominating a new particle. We want thus two innested loops both iterating on all particles. The only skippable comparisons are between pareto-pareto particles and thus if both indexes i and j are less than the pareto length.