### PR TITLE
Fix inconsistent value types when updating particles' postions

### DIFF
--- a/optimizer/mopso/mopso.py
+++ b/optimizer/mopso/mopso.py
@@ -116,7 +116,7 @@ class MOPSO(Optimizer):
                         raise ValueError(
                             f"Type {type(self.lower_bounds[i])} not supported")
                     positions.append(position)
-                return np.array(positions)
+                return np.array(positions, dtype=object)
             [particle.set_position(random_position())
              for particle in self.particles]
         elif initial_particles_position == 'gaussian':


### PR DESCRIPTION
The particles' positions were being updated using numpy arrays which default to using a single type for their content. Adding the `dtype` option fixes the issue, maintaining the correct type of each parameter